### PR TITLE
Fix netcat error on RPi, bind to IP instead of localhost

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -123,7 +123,7 @@ if [ "$selection" == "1" ]
 then
     echo "> what is the IP or FQDN of the projector you want to interact with?"
     read projector
-    if ! nc -z -w 3 -G 3 $projector 4352 2>/dev/null
+    if ! nc -z -w 3 -G 4 $projector 4352 2>/dev/null
     then
         echo -e ">   ${RED}unreachable${RESET}"
         echo -e "I couldn't open a socket to $projector on tcp:4352. Might be routing, might be firewalling, impossible to tell from here. Maybe the PJLink protocol is disabled in the settings? Please make sure that the network you are on allows you to talk to this projector and try again."
@@ -386,7 +386,7 @@ echo -e ">   finding available port"
 for orchestrator_port in $(seq 81 65535)
 do
     echo -e ">     $orchestrator_port"
-    if ! nc -z -w 3 -G 3 localhost $orchestrator_port 2>/dev/null
+    if ! nc -z -w 3 -G 4 localhost $orchestrator_port 2>/dev/null
     then
         break
     fi
@@ -413,7 +413,7 @@ echo -e ">   finding available port"
 for ui_port in $(seq 80 65535)
 do
     echo -e ">     $ui_port"
-    if ! nc -z -w 3 -G 3 localhost $ui_port 2>/dev/null
+    if ! nc -z -w 3 -G 4 localhost $ui_port 2>/dev/null
     then
         break
     fi

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -11,6 +11,7 @@ CYAN="\033[36m"
 WHITE="\033[37m"
 RESET="\033[0m"
 
+current_ip=$(hostname -I | awk '{print $1}')
 
 read_input_with_choices() {
     local choices="$@"
@@ -386,7 +387,7 @@ echo -e ">   finding available port"
 for orchestrator_port in $(seq 81 65535)
 do
     echo -e ">     $orchestrator_port"
-    if ! nc -z -w 3 -G 4 localhost $orchestrator_port 2>/dev/null
+    if ! nc -z -w 3 -G 4 $current_ip $orchestrator_port 2>/dev/null
     then
         break
     fi
@@ -413,7 +414,7 @@ echo -e ">   finding available port"
 for ui_port in $(seq 80 65535)
 do
     echo -e ">     $ui_port"
-    if ! nc -z -w 3 -G 4 localhost $ui_port 2>/dev/null
+    if ! nc -z -w 3 -G 4 $current_ip $ui_port 2>/dev/null
     then
         break
     fi
@@ -421,7 +422,7 @@ done
 docker run -tdi \
     --restart unless-stopped \
     -p $ui_port:80 \
-    -e HOME_ORCHESTRATOR=http://localhost:$orchestrator_port \
+    -e HOME_ORCHESTRATOR=http://$current_ip:$orchestrator_port \
     --network openav \
     --network-alias frontend-web \
     --name frontend-web \
@@ -433,5 +434,7 @@ then
     ui_port_if_not_80=":$ui_port"
 fi
 
-echo "> orchestrator available at: http://localhost:$orchestrator_port"
-echo "> UI available at: http://localhost$ui_port_if_not_80?system=test_123"
+echo "> orchestrator available at: http://$current_ip:$orchestrator_port"
+echo "> ...or http://localhost:$orchestrator_port"
+echo "> UI available at: http://$current_ip$ui_port_if_not_80?system=test_123"
+echo "> ...or http://localhost:$ui_port_if_not_80?system=test_123"


### PR DESCRIPTION
Two changes:
1. Bind to assigned IP instead of 'localhost' to allow headless operation.  Using 'localhost' still works.
2. Fix netcat (netcat-traditional on Raspberry Pi OS) "invalid hop pointer 3, must be multiple of 4 <= 28"