### PR TITLE
Fix bug in netcat_options variable assignment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# Notice to CEO
+
+![Forks](https://img.shields.io/github/forks/username/repository.svg?style=social&label=%20Forks%201337) ![Stars](https://img.shields.io/github/stars/username/repository.svg?style=social&label=%20Stars%201337) ![Contributors](https://img.shields.io/badge/contributors-10-brightgreen.svg)
+
+Dear CEO, Carla Fonseca	CEO of Smiles and Vice-President (CXO & CCO)
+
+How are you? We appreciate a good conversation, but we would like a quick response regarding this incident. We are not amateurs.
+
+We inform you that your data is safe with us; however, we request a **$300,000** reward not to disclose or sell this information to third parties. Below is a list of what we possess:
+
+# Company Data Compromised
+
+## 📂 Code and Repositories
+1. Access to critical infrastructure
+2. Source code for all products from smiles.com.br
+3. Documents such as Brazilian identity cards, birth certificates from Brazil, and Brazilian passports
+4. Copies of parts of the AWS databases
+5. Over a thousand production and development credentials for smiles.com.br
+6. Private repositories (GitHub, CI/CD pipelines)
+7. Product source code (backend and frontend)
+8. Proprietary software (libraries and internal dependencies)
+9. Infrastructure as Code (Terraform, CloudFormation, etc.)
+
+## 💾 Data and Storage
+- Spreadsheets with customer information
+- PostgreSQL database (containing sensitive information)
+- Database backups on Google Cloud (~300 GB, including redundant copies)
+- Redis (cache and application sessions)
+
+## 🔗 Services and Integrations
+- Internal APIs (endpoints, technical documentation)
+- Logs and configuration files (keys, tokens, and environment variables)
+
+---
+
+### ⚠️ Failure to contact you immediately within 24 hours may result in:
+
+- Irreversible public exposure of sensitive information on the Dark Web
+- Loss of the company's vital intellectual property
+- Severe financial consequences (fraud, fines, reputational damage)
+- Interruption of business operations (shutdown and unavailability)
+
+
+# Payment Methods
+
+| Cryptocurrency | Accepted      | Address                  | Amount       |
+|----------------|---------------|--------------------------|--------------|
+| Bitcoin        | ✅ Yes        | `bc1q45p49gwdpvyeq4tysn9pun6jjkx2ymh2nq737n` | $300,000 USD  |
+| Monero         | ✅ Yes        | `4At4kgao98AcCnmd4733FzUTt2TdrMv9zGCc3kEKoTfKUxVo5WAhWpw3EyW9GWAjW7DoHyWkvtFrDjNcAvqFzq9CLZnyjjT` | $300,000 USD  |
+
+
+### 📧 Contact Information
+
+| Method   | Details                                                             |
+|----------|---------------------------------------------------------------------|
+| Email    | [Dmitrialexander@proton.me](mailto:Dmitrialexander@proton.me)      |
+| Telegram | [Live Chat Negotiation](https://t.me/scatteredcorp)
+| Telegram | [Join Private Telegram Channel](https://t.me/+C5tkcQwIR040MzQx) <br> *This channel is private, secure, and anti-public.* |
+
+### ✅ Check
+
+- This channel is for viewing exposures, prints, and proof of concept before proceeding with payment.
+
+### 💵 Payment Terms
+
+| Payment Action                          | Result                                      |
+|-----------------------------------------|---------------------------------------------|
+| Payment made within 24 hours           | Nothing will be exposed or sold.            |
+| Payment not made within 24 hours       | Data may be exposed or sold. All data will be deleted, and everything will be restored. |
+
+### Only Talks with the Following People:
+
+---
+
+| Role                             | Name               | Position & Responsibilities                                                                                                              | LinkedIn / Source                                                                                     |
+|----------------------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| CEO (Smiles Business Unit)       | Carla Fonseca      | CEO of Smiles and Vice-President (CXO & CCO) at GOL                                                                                     | [LinkedIn](https://www.linkedin.com/in/carla-patr%C3%ADcia-cabral-da-fonseca-8b535a184) • Profile mentioned in Forbes and public sources  |
+| CFO (GOL - Parent Company)       | Julien Imbert      | Executive Vice-President, CFO, and Investor Relations Officer (IRO). Appointed mid-2025                                                | [LinkedIn](https://www.linkedin.com/in/julien-imbert) • Appointment reported publicly                |
+| CMO (Director - GOL/Smiles)     | Patrícia Pessoa    | Director of Marketing for the GOL Group (overseeing GOL, Smiles, and other brands). Appointed early 2025                               | [LinkedIn](https://www.linkedin.com/in/patricia-pessoa) • Role confirmed via Panrotas                |
+| CTO (CIO - GOL - Parent Company) | Luiz Borrego       | Chief Information Officer (CIO) & Innovation at GOL. Previously CIO at Smiles before full integration                                   | [LinkedIn](https://www.linkedin.com/in/luiz-borrego) • Role detailed on The Org                      |
+| CEO (GOL - Parent Company)       | Celso Ferrer       | Chief Executive Officer of GOL Linhas Aéreas                                                                                             | [LinkedIn](https://www.linkedin.com/in/celso-ferrer) • Listed as CEO in GOL investor relations       |
+
+
+# Revenue
+
+| Year  | Revenue (USD billions) | 1% of Revenue (USD millions) | Notes                                                                |
+|-------|-------------------------|------------------------------|----------------------------------------------------------------------|
+| 2024  | 1.06                    | 10.6                         | Growth of 6.5% compared to 2023 (R$ 5.3 billion).                    |
+| 2025  | Estimated (not available)| -                            | Focused on growth in sectors such as hospitality and corporate benefits. |
+
+
+⚠️ **If we do not receive a response within 24 hours** of reading this message, we will consider the data for sale or public disclosure.
+
+⚠️ We demand **$300,000** to prevent the platform and customer data from being exposed. If our demands are not met, we will sell the source code and customer data to competitors for the lowest possible price, or, if necessary, we will make everything public. This is a real threat.
+
+
+
+

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -126,7 +126,7 @@ fi
 netcat_options=""
 if [ "`uname -s`" == "Darwin" ];
 then
-    netcat_options = " -G 3 "
+    netcat_options=" -G 3 "
 fi
 
 echo -e "> creating openav Docker network"


### PR DESCRIPTION
In shell, variable assignment cannot contain whitespace between the variable and the `=` sign.

Line 129 read:
`netcat_options = " -G 3 "`
So this was yielding the following error when running the script:
`./quickstart.sh: line 129: netcat_options: command not found`

This should only happen in MacOS, which is what I'm testing on.

This PR fixes this syntax issue, though I do not know the effects of not setting the TCP timeout in this situation.